### PR TITLE
Fix | Routes |: block unpublished routes to be visited

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -264,10 +264,10 @@ const router = createRouter({
 router.beforeEach(async (to, from, next) => {
   if (to.meta.blocked) {
     next({ path: "/" })
-    return
+  } else {
+    await fillUserState();
+    next()
   }
-  await fillUserState();
-  next()
 });
 // Обновляем title при переходах между страницами
 router.afterEach(async (to) => {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -248,12 +248,12 @@ const routes = [
         path: "venues",
         component: AdminVenues
       },
-      {
-        path: '/:pathMatch(.*)*',
-        redirect: "/login"
-      },
     ]
-  }
+  },
+  {
+    path: '/:pathMatch(.*)*',
+    redirect: "/login"
+  },
 ];
 
 const router = createRouter({

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -47,7 +47,6 @@ import AdminExperts from '@/views/admin/AdminExperts.vue';
 import AdminCompetencies from '@/views/admin/AdminCompetencies.vue';
 import AdminDocuments from '@/views/admin/AdminDocuments.vue';
 import AdminVenues from '@/views/admin/AdminVenues.vue';
-import { JwtManager } from '@/utils/JwtManager.ts';
 
 const routes = [
   {
@@ -261,6 +260,8 @@ const router = createRouter({
   routes,
 });
 
+export const historyStack = []
+
 router.beforeEach(async (to, from, next) => {
   if (to.meta.blocked) {
     next({ path: "/" })
@@ -270,13 +271,15 @@ router.beforeEach(async (to, from, next) => {
   }
 });
 // Обновляем title при переходах между страницами
-router.afterEach(async (to) => {
+router.afterEach(async (to, from) => {
   const pageTitle = titleManager.getPageTitle(
     to.name
       ? to.name.toString()
       : "No title"
   );
+  historyStack.push(from.fullPath);
   titleManager.setTitle(pageTitle);
+
   await redirectByUserState();
 });
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -47,6 +47,7 @@ import AdminExperts from '@/views/admin/AdminExperts.vue';
 import AdminCompetencies from '@/views/admin/AdminCompetencies.vue';
 import AdminDocuments from '@/views/admin/AdminDocuments.vue';
 import AdminVenues from '@/views/admin/AdminVenues.vue';
+import { JwtManager } from '@/utils/JwtManager.ts';
 
 const routes = [
   {
@@ -59,19 +60,16 @@ const routes = [
     component: LoginView,
   },
   {
-    path: "/register",
-    name: "register",
-    component: MentorRegisterView,
-  },
-  {
     path: "/register/mentor",
     name: "mentor-register",
     component: MentorRegisterView,
+    meta: { blocked: true },
   },
   {
     path: "/register/parent",
     name: "parent-register",
     component: ParentRegisterView,
+    meta: { blocked: true },
   },
   {
     path: "/register/tutor",
@@ -86,6 +84,7 @@ const routes = [
   {
     path: "/parent",
     component: ParentDashboard,
+    meta: { blocked: true },
     children: [
       {
         path: "",
@@ -116,6 +115,7 @@ const routes = [
   {
     path: "/mentor",
     component: MentorDashboard,
+    meta: { blocked: true },
     children: [
       {
         path: "",
@@ -248,6 +248,10 @@ const routes = [
         path: "venues",
         component: AdminVenues
       },
+      {
+        path: '/:pathMatch(.*)*',
+        redirect: "/login"
+      },
     ]
   }
 ];
@@ -257,8 +261,13 @@ const router = createRouter({
   routes,
 });
 
-router.beforeEach(async () => {
+router.beforeEach(async (to, from, next) => {
+  if (to.meta.blocked) {
+    next({ path: "/" })
+    return
+  }
   await fillUserState();
+  next()
 });
 // Обновляем title при переходах между страницами
 router.afterEach(async (to) => {

--- a/src/utils/JwtManager.ts
+++ b/src/utils/JwtManager.ts
@@ -1,0 +1,19 @@
+import { Roles } from '@/state/UserState.types.ts';
+import { jwtDecode } from 'jwt-decode';
+
+export class JwtManager {
+  public static decode(token: string): UserJwt {
+    return jwtDecode<UserJwt>(token);
+  }
+}
+
+interface UserJwt {
+  id: number;
+  email: string;
+  role: Roles;
+  iat: number;
+  exp: number;
+  header: {
+    alg: string;
+  }
+}

--- a/src/views/auth/EmailConfirmationView.vue
+++ b/src/views/auth/EmailConfirmationView.vue
@@ -94,7 +94,7 @@ import type {
   TutorStateInterface,
 } from "@/state/UserState.types";
 import { fillUserState, redirectByUserState } from "@/state/UserState";
-import router from '@/router';
+import router, { historyStack } from '@/router';
 
 export default {
   name: "EmailConfirmationView",
@@ -216,8 +216,11 @@ export default {
       }
     },
 
-    goBack() {
-      router.go(-1)
+    async goBack() {
+      const registerStack = historyStack.filter(routePath => routePath.includes("register"));
+      if (registerStack.length > 0) {
+        await router.push(registerStack[registerStack.length - 1])
+      } else await router.push("/")
     },
   },
 };

--- a/src/views/auth/EmailConfirmationView.vue
+++ b/src/views/auth/EmailConfirmationView.vue
@@ -94,6 +94,7 @@ import type {
   TutorStateInterface,
 } from "@/state/UserState.types";
 import { fillUserState, redirectByUserState } from "@/state/UserState";
+import router from '@/router';
 
 export default {
   name: "EmailConfirmationView",
@@ -117,15 +118,16 @@ export default {
         code: "",
       },
       authResolver: new AuthResolver(),
-      registrationData: (
-        JSON.parse(localStorage.getItem("dataToVerify") as string) as RegistrationData<
-          UserWithChildRegistrationDto | UserRegistrationDto,
-          TutorStateInterface | MentorStateInterface | ParentStateInterface
-        >
-      ).dto as UserRegistrationDto | UserWithChildRegistrationDto,
+      registrationData: null as null | UserWithChildRegistrationDto | UserRegistrationDto,
     };
   },
   mounted() {
+    this.registrationData = localStorage.getItem("dataToVerify")
+      ? (JSON.parse(localStorage.getItem("dataToVerify") as string) as RegistrationData<
+          UserWithChildRegistrationDto | UserRegistrationDto,
+          TutorStateInterface | MentorStateInterface | ParentStateInterface
+        >).dto as UserRegistrationDto | UserWithChildRegistrationDto
+      : null
     // Получаем email из query параметров или localStorage
     this.userEmail =
       this.$route.query.email as string ||
@@ -215,7 +217,7 @@ export default {
     },
 
     goBack() {
-      this.$router.push("/register");
+      router.go(-1)
     },
   },
 };


### PR DESCRIPTION
By this pull request users won't be able to visit restricted routes with _blocked_ modifier. Also all unmounted routes will be redirected to Login page (temporarily).

This resolves #50 